### PR TITLE
Tweak: Removed text domain loading method in favor of WordPress standard loading

### DIFF
--- a/aryo-activity-log.php
+++ b/aryo-activity-log.php
@@ -82,13 +82,6 @@ final class AAL_Main {
 	public $notifications;
 
 	/**
-	 * Load text domain
-	 */
-	public function load_textdomain() {
-		load_plugin_textdomain( 'aryo-activity-log' );
-	}
-
-	/**
 	 * Construct
 	 */
 	protected function __construct() {
@@ -105,8 +98,6 @@ final class AAL_Main {
 
 		// set up our DB name
 		$wpdb->activity_log = $wpdb->prefix . 'aryo_activity_log';
-
-		add_action( 'plugins_loaded', array( &$this, 'load_textdomain' ) );
 	}
 
 	/**
@@ -119,8 +110,15 @@ final class AAL_Main {
 	 * @return void
 	 */
 	public function __clone() {
-		// Cloning instances of the class is forbidden
-		_doing_it_wrong( __FUNCTION__, __( 'Cheatin&#8217; huh?', 'aryo-activity-log' ), '2.0.7' );
+		_doing_it_wrong(
+			__FUNCTION__,
+			sprintf(
+				/* translators: %s: Class name. */
+				__( 'Cloning instances of the singleton "%s" class is forbidden.', 'aryo-activity-log' ),
+				get_class( $this )
+			),
+			'2.0.7'
+		);
 	}
 
 	/**
@@ -130,8 +128,15 @@ final class AAL_Main {
 	 * @return void
 	 */
 	public function __wakeup() {
-		// Unserializing instances of the class is forbidden
-		_doing_it_wrong( __FUNCTION__, __( 'Cheatin&#8217; huh?', 'aryo-activity-log' ), '2.0.7' );
+		_doing_it_wrong(
+			__FUNCTION__,
+			sprintf(
+				/* translators: %s: Class name. */
+				__( 'Unserializing instances of the singleton "%s" class is forbidden.', 'aryo-activity-log' ),
+				get_class( $this )
+			),
+			'2.0.7'
+		);
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: elemntor, KingYes, ariel.k
 Tags: Activity Log, User Log, Audit Log, Security, Email Log,
 Requires at least: 6.0
-Requires PHP: 7.0
+Requires PHP: 7.4
 Tested up to: 7.1
 Stable tag: 2.12.0
 License: GPLv2 or later
@@ -99,7 +99,7 @@ Uninstalling the plugin removes all of its data from your database automatically
 == Frequently Asked Questions ==
 
 = Requirements =
-__Requires PHP 7.0__ for list management functionality.
+__Requires PHP 7.4__ for list management functionality.
 
 = What is the plugin license? =
 
@@ -425,8 +425,8 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 * Added filter by date - All Time, Today, Yesterday, Week, Month
 * Added Avatar to author
 * Added role for author
-* Added log for activeted theme
-* Re-order Culoumns
+* Added log for activated theme
+* Re-order Columns
 * Compatible up to 3.8.1
 * Settings page is now accessible directly from Activity Log's menu
 * Keep your log for any time your wants


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Removes custom textdomain loading in favor of WordPress's standard hook-based approach, delegating to `load_plugin_textdomain()` via plugins_loaded. Improves error messages in singleton validation methods with translatable sprintf formatting.

## 2. What Changed (Where)

**aryo-activity-log.php**: Removed `load_textdomain()` method and its `plugins_loaded` hook registration; enhanced `__clone()` and `__wakeup()` error messages with proper i18n formatting and descriptive text.

## 3. How It Works

Textdomain loading now relies on WordPress standard discovery (likely via plugin header), eliminating custom hook logic. Singleton guards emit clearer, translatable warnings via `_doing_it_wrong()` with class name and version context.

## 4. Risks

None — textdomain loading moved to standard WordPress mechanism; error messages improved. Confirm `load_plugin_textdomain()` is invoked elsewhere (plugin header or bootstrap) to avoid silent translation failures.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
