### PR TITLE
Tweak: Move App Password badge to User column

### DIFF
--- a/assets/js/admin/src/app.js
+++ b/assets/js/admin/src/app.js
@@ -31,7 +31,7 @@ const styles = {
 	loading: { textAlign: 'center', padding: '40px 0' },
 	pagination: { display: 'flex', alignItems: 'center', gap: 8, marginTop: 12, justifyContent: 'flex-end' },
 	paginationInfo: { fontSize: 13, color: '#50575e' },
-	badgeBase: { display: 'inline-block', padding: '1px 6px', borderRadius: 3, fontSize: 12, lineHeight: '18px', textDecoration: 'none' },
+	badgeBase: { display: 'inline-block', padding: '1px 6px', borderRadius: 3, fontSize: 'inherit', lineHeight: '14px', textDecoration: 'none' },
 	badgeChannel: { background: '#e7f0f7', color: '#1e4d78' },
 	badgeApp: { background: '#f0e7f7', color: '#4d1e78' },
 	noItems: { textAlign: 'center', padding: 20, color: '#646970' },
@@ -523,6 +523,12 @@ function LogRow( { item, params, onFilter } ) {
 				) }
 				{ author.role && <br /> }
 				{ author.role && <small>{ author.role }</small> }
+				{ source.app_name && (
+					<>
+						<br />
+						<small><SourceBadge type="app">{ source.app_name }</SourceBadge></small>
+					</>
+				) }
 			</td>
 			<td>
 				{ source.channel_label && (
@@ -536,12 +542,6 @@ function LogRow( { item, params, onFilter } ) {
 						>
 							{ source.channel_label }
 						</SourceBadge>
-						<br />
-					</>
-				) }
-				{ source.app_name && (
-					<>
-						<SourceBadge type="app">{ source.app_name }</SourceBadge>
 						<br />
 					</>
 				) }

--- a/classes/class-aal-export.php
+++ b/classes/class-aal-export.php
@@ -64,10 +64,11 @@ class AAL_Export {
 		$result = $query->query( $query_args );
 
 		$columns = array(
-			'date'        => __( 'Date', 'aryo-activity-log' ),
-			'author'      => __( 'User', 'aryo-activity-log' ),
-			'source'      => __( 'Source', 'aryo-activity-log' ),
-			'type'        => __( 'Topic', 'aryo-activity-log' ),
+			'date'         => __( 'Date', 'aryo-activity-log' ),
+			'author'       => __( 'User', 'aryo-activity-log' ),
+			'app_password' => __( 'App Password', 'aryo-activity-log' ),
+			'source'       => __( 'Source', 'aryo-activity-log' ),
+			'type'         => __( 'Topic', 'aryo-activity-log' ),
 			'label'       => __( 'Context', 'aryo-activity-log' ),
 			'description' => __( 'Meta', 'aryo-activity-log' ),
 			'action'      => __( 'Action', 'aryo-activity-log' ),

--- a/classes/class-aal-log-presenter.php
+++ b/classes/class-aal-log-presenter.php
@@ -50,6 +50,15 @@ class AAL_Log_Presenter {
 					$row[ $column ] = isset( $user->display_name ) ? $user->display_name : 'unknown';
 					break;
 
+				case 'app_password':
+					if ( AAL_Maintenance::is_schema_ready( '1.1' ) && ! empty( $item->request_source ) ) {
+						$parsed = AAL_API::parse_request_source( $item->request_source );
+						$row[ $column ] = $parsed['app_name'];
+					} else {
+						$row[ $column ] = '';
+					}
+					break;
+
 				case 'source':
 					if ( AAL_Maintenance::is_schema_ready( '1.1' ) && ! empty( $item->request_source ) ) {
 						$row[ $column ] = self::format_source_label_plain( $item->request_source );
@@ -275,12 +284,6 @@ class AAL_Log_Presenter {
 
 		if ( ! empty( $parsed['channel'] ) && isset( $channel_labels[ $parsed['channel'] ] ) ) {
 			$parts[] = $channel_labels[ $parsed['channel'] ];
-		}
-
-		if ( ! empty( $parsed['app_name'] ) ) {
-			$parts[] = 'App Password: ' . $parsed['app_name'];
-		} elseif ( false !== strpos( $raw, 'app:' ) ) {
-			$parts[] = 'App Password';
 		}
 
 		return implode( '; ', $parts );

--- a/tests/phpunit/test-export.php
+++ b/tests/phpunit/test-export.php
@@ -119,4 +119,49 @@ class AAL_Test_Export extends WP_UnitTestCase {
 		$this->assertSame( '192.168.1.1', $row['ip'] );
 		$this->assertSame( '', $row['source'] );
 	}
+
+	public function test_export_row_app_password_column_with_app() {
+		$columns = [
+			'app_password' => 'App Password',
+			'source'       => 'Source',
+		];
+
+		$item = (object) [
+			'hist_ip'        => '',
+			'request_source' => 'rest|app:My App',
+			'hist_time'      => time(),
+			'user_id'        => 0,
+			'object_type'    => 'Posts',
+			'object_subtype' => 'post',
+			'object_name'    => 'hello',
+			'action'         => 'updated',
+		];
+
+		$row = AAL_Log_Presenter::to_export_row( $item, $columns );
+
+		$this->assertSame( 'My App', $row['app_password'] );
+		$this->assertStringNotContainsString( 'App Password', $row['source'] );
+	}
+
+	public function test_export_row_app_password_column_without_app() {
+		$columns = [
+			'app_password' => 'App Password',
+			'source'       => 'Source',
+		];
+
+		$item = (object) [
+			'hist_ip'        => '',
+			'request_source' => 'rest',
+			'hist_time'      => time(),
+			'user_id'        => 0,
+			'object_type'    => 'Posts',
+			'object_subtype' => 'post',
+			'object_name'    => 'hello',
+			'action'         => 'updated',
+		];
+
+		$row = AAL_Log_Presenter::to_export_row( $item, $columns );
+
+		$this->assertSame( '', $row['app_password'] );
+	}
 }


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Move the App Password badge from the Source column to the User column for better UX clarity—app authentication method is user-centric, not source metadata.

## 2. What Changed (Where)

- **Export logic**: Reordered columns array; added dedicated `app_password` column case in `to_export_row()` 
- **Source formatting**: Removed app name from `format_source_label_plain()` output
- **UI**: Relocated app badge rendering from Source cell to User cell; adjusted badge base styles (font sizing)
- **Tests**: Added two test cases validating app password column exports with/without app name

## 3. How It Works

When rendering a log row, `app_password` is now extracted directly from `request_source` via `AAL_API::parse_request_source()` and rendered as a small badge beneath the user's role in the User column—no longer mixed into the Source column's channel/IP display.

## 4. Risks

None identified. Column reordering is transparent to consumers; badge relocation is UI-only; tests validate both cases (with app vs. REST without app).

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
